### PR TITLE
Force certain webpack loaders to resolve by aliased namespace/package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+1.1.0 (Unreleased)
+------------------
+
+- The base loader plugin handler will also generate a modname prefixed
+  with ``./``, in an attempt to provide a more natural include mechanism
+  from within certain webpack loader contexts, as a number of them will
+  implicitly resolve by relative path for a bare import, and the goal is
+  to avoid further proprietary webpack syntaxes (e.g. the usage of the
+  ``~`` prefixes to some ``namespace/package`` import/inclusions done
+  inside the loader context).  [
+  `#4 <https://github.com/calmjs/calmjs.webpack/issues/4>`_
+  ]
+
 1.0.2 (2018-05-24)
 ------------------
 

--- a/src/calmjs/webpack/loaderplugin.py
+++ b/src/calmjs/webpack/loaderplugin.py
@@ -40,7 +40,19 @@ class BaseWebpackLoaderHandler(LoaderPluginHandler):
         shutil.copy(source, copy_target)
 
         modpaths = {modname: modpath}
-        targets = {stripped_modname: target}
+        targets = {
+            stripped_modname: target,
+            # Also include the relative path as a default alias so that
+            # within the context of the loader, any implicit joining of
+            # the current directory (i.e. './') with any declared
+            # modnames within the system will not affect the ability to
+            # do bare imports (e.g. "namespace/package/resource.data")
+            # within the loader's interal import system.
+            #
+            # Seriously, forcing the '~' prefixes on all user imports
+            # is simply unsustainable importability.
+            './' + stripped_modname: target,
+        }
         export_module_names = [modname]
         return modpaths, targets, export_module_names
 

--- a/src/calmjs/webpack/tests/test_loaderplugin.py
+++ b/src/calmjs/webpack/tests/test_loaderplugin.py
@@ -80,8 +80,10 @@ class WebpackLoaderPluginTestCase(unittest.TestCase):
 
         self.assertEqual(
             {'text!some.file.txt': 'text!some.file.txt'}, modpaths)
-        self.assertEqual(
-            {'some.file.txt': 'some.file.txt'}, targets)
+        self.assertEqual({
+            'some.file.txt': 'some.file.txt',
+            './some.file.txt': 'some.file.txt',
+        }, targets)
         self.assertEqual(
             ['text!some.file.txt'], export_module_names)
 
@@ -105,8 +107,10 @@ class WebpackLoaderPluginTestCase(unittest.TestCase):
 
         self.assertEqual(
             {'text!some.file.txt': 'text!some.file.txt'}, modpaths)
-        self.assertEqual(
-            {'some.file.txt': tgtfile}, targets)
+        self.assertEqual({
+            'some.file.txt': tgtfile,
+            './some.file.txt': tgtfile,
+        }, targets)
         self.assertEqual(
             ['text!some.file.txt'], export_module_names)
 
@@ -129,8 +133,10 @@ class WebpackLoaderPluginTestCase(unittest.TestCase):
 
         self.assertEqual(
             {'text!css!some.css': 'text!css!some.css'}, modpaths)
-        self.assertEqual(
-            {'some.css': 'some.css'}, targets)
+        self.assertEqual({
+            'some.css': 'some.css',
+            './some.css': 'some.css',
+        }, targets)
         self.assertEqual(
             ['text!css!some.css'], export_module_names)
 


### PR DESCRIPTION
Given the lack of the concept of namespaces or modules from within the environment, typical `webpack` loaders will implicitly append a `./`, such that the resolution of `'namespace/module'` is turned into `'./namespace/module'` (which leads to the wrong location as the build directory is almost never the current directory), unless a `~` is prepended (i.e. `'~namespace/module'`) to force the lookup.  So to ensure that the calmjs system works as expected, also supply the `./` prefixed to the alias mapping as part of the standard `BaseWebpackLoaderHandler` class. For webpack loaders that fully respect the `resolve.alias` mapping, it will enforce the correct behavior (tested with `style-loader` and `sass-loader`).

Reference:
- https://github.com/webpack-contrib/less-loader/issues/74#issuecomment-201847685