### PR TITLE
First class support for generic loader and definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,19 @@ matrix:
     - language: node_js
       node_js: 4.9
       os: osx
-      env: TRAVIS_PYTHON_VERSION=3.4.5
+      env: TRAVIS_PYTHON_VERSION=3.4.8
     - language: node_js
       node_js: 6.14
       os: osx
-      env: TRAVIS_PYTHON_VERSION=3.5.3
+      env: TRAVIS_PYTHON_VERSION=3.5.5
     - language: node_js
       node_js: 8.11
       os: osx
-      env: TRAVIS_PYTHON_VERSION=3.6.0
+      env: TRAVIS_PYTHON_VERSION=3.6.6
+    - language: node_js
+      node_js: 10
+      os: osx
+      env: TRAVIS_PYTHON_VERSION=3.7.0
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -82,7 +86,7 @@ script:
   # run the first test without calmjs.dev.
   - python -m unittest calmjs.webpack.tests.make_suite
   # run the real test with all optional dependencies.
-  - pip install calmjs.dev
+  - pip install -e .[dev]
   - coverage run --include=src/* -m unittest calmjs.webpack.tests.make_suite
   - coverage report -m
 after_success:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,19 @@ Changelog
 1.1.0 (Unreleased)
 ------------------
 
+- Provide support of prefix-free loaders through a customized webpack
+  loader module registry; this one also works in tandem with the
+  ``calmjs.module`` registry.  [
+  `#5 <https://github.com/calmjs/calmjs.webpack/issues/5>`_
+  ]
+
+  - Integrate the support of the package resource loader registry
+    introduced by ``calmjs-3.3.0``.
+  - Bumped supported ``calmjs.dev`` to version 2.2.0 such that the
+    correct test loader registries can be automatically acquired.  This
+    also makes it possible to declare test data files as resources for
+    JavaScript tests in the most straightforward manner as possible
+
 - The base loader plugin handler will also generate a modname prefixed
   with ``./``, in an attempt to provide a more natural include mechanism
   from within certain webpack loader contexts, as a number of them will

--- a/README.rst
+++ b/README.rst
@@ -627,7 +627,7 @@ following entry point on the ``calmjs.module.loader`` registry::
 With the above definition, importing stylesheet resources using the
 complete syntax (i.e. ``require('style!css!example/app/style.css');``
 will work, but it is incompatible with the ``require-css`` loader as
-it does not necessarily support the chaining of the ``style`` loader
+it does not necessarily support the chaining of the ``style!`` loader
 prefix as the RequireJS version of the plugin will apply the styles
 immediately without that (this is why the loader-prefixes are considered
 non-portable).
@@ -638,7 +638,7 @@ loaded, so that the loaderprefix-free loading can be achieved (i.e. the
 previous JavaScript fragment).  To specifically support this through
 Calmjs, the resources entry points should be defined under the
 ``calmjs.module.webpackloader`` registry instead of the common
- ``calmjs.module.loader`` registry.  For example:
+``calmjs.module.loader`` registry.  For example:
 
 .. code:: ini
 
@@ -647,35 +647,55 @@ Calmjs, the resources entry points should be defined under the
     example.app = example.app
 
     [calmjs.module.webpackloader]
+    style-loader!css-loader = stylesheet[css]
+    text-loader = txt[txt]
+
+Please note that while it is possible to also define the entry point
+like the following:
+
+.. code:: ini
+
+    [calmjs.module.webpackloader]
     style!css = stylesheet[css]
-    text = txt[txt]
+
+Previously this relies on a legacy behavior which |webpack| removed, but
+it is still supported by |calmjs| and |calmjs.webpack| simply due to the
+generic support of this format, but given that this registry is
+specifically for webpack, there is should be no issue if the webpack
+specific syntax is used, if the following caveats are addressed.
 
 Please note that if a given file name extension is defined on multiple
 webpackloaders (note that the text loader has removed json as a file
 name extension), the resulting behavior is undefined as the generated
 configuration will not guarantee that the loaders are chained together
 in the expected manner, as both loaders will be applied to the selected
-files under an undefined ordering.  If a file name extension defined in
-this is also defined in the ``calmjs.module.loader`` registry, it will
-also cause complications.
+files under an undefined ordering.
+
+Module names exported by the ``calmjs.module.webpackloader`` will not be
+made available the gathered module or import names for the dynamic
+import module when processed by the default loader plugin handlers, as
+there exists a number of subtle complexities that severely complicates
+exposing these names in a meaningful manner for usage within the calmjs
+system.  In effect, no dynamic imports will be possible after the
+construction of the artifact.
+
+If a file name extension defined in this is also defined in the
+``calmjs.module.loader`` registry, it will also cause complications if
+the dynamic import module was also generated.  This issue is related to
+the issue outlined by the previous paragraph.
 
 If multiple loaders are required (such as for the case of stylesheets),
-use the chained syntax as in the ``style!css`` definition to ensure that
-they are applied correctly, much like they would have been if they were
-prefixed on the imports directly for this particular Python package.
+use the chained syntax as in the ``style-loader!css-loader`` definition
+to ensure that they are applied correctly, much like they would have
+been if they were prefixed on the imports directly for this particular
+Python package (i.e. ``style!css!``).
 
 Much like the standard ``calmjs.module.loader`` registry, the
-definitions to the filename extensions are local to the package, so that
-definitions that make use of a different set of loaders from an upstream
-or downstream package will not cause interference with how they are
-applied.
-
-Also note that this registry will not make available the gathered module
-or import names for the dynamic module imports by the default loader
-plugin handlers, as there exists a number of subtle complexities that
-severely complicates exposing these names in a meaningful manner for
-usage within the calmjs system.  In effect, no dynamic imports will be
-possible after the construction of the artifact.
+definitions for any given filename extensions declared under the
+``calmjs.module.webpackloader`` registry are local to the package, so
+that definitions that make use of a different set of loaders from an
+upstream or downstream package will not cause interference with how they
+are applied.
 
 Testing standalone, finalized webpack artifacts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ test_script:
   # verify tests working without optional dependencies
   - python -m unittest calmjs.webpack.tests.make_suite
   # run the full test suite using all optional dependencies
-  - pip install calmjs.dev
+  - pip install -e .[dev]
   - coverage run --include=src/* -m unittest calmjs.webpack.tests.make_suite
   - coverage report -m
 

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'calmjs>=3.0.0dev',
-        'calmjs.parse',
+        'calmjs>=3.3.0dev',
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     ],
     extras_require={
         'dev': [
-            'calmjs.dev>=2.0.0,<3',
+            'calmjs.dev>=2.2.0,<3',
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,15 @@ setup(
         'calmjs.registry': [
             'calmjs.webpack.loaderplugins = '
             'calmjs.webpack.loaderplugin:AutogenWebpackLoaderPluginRegistry',
+
             'calmjs.webpack.static.loaderplugins = '
             'calmjs.loaderplugin:LoaderPluginRegistry',
+
+            'calmjs.module.webpackloader = '
+            'calmjs.webpack.loaderplugin:WebpackModuleLoaderRegistry',
+
+            'calmjs.module.tests.webpackloader = '
+            'calmjs.webpack.loaderplugin:WebpackModuleLoaderRegistry',
         ],
         'calmjs.webpack.static.loaderplugins': [
             'text = calmjs.webpack.loaderplugin:WebpackLoaderHandler',

--- a/src/calmjs/webpack/README.rst
+++ b/src/calmjs/webpack/README.rst
@@ -1,9 +1,9 @@
 Module layout
 =============
 
-This module, ``calmjs.webpack``, also follows the ``calmjs`` module
-layout order, but for clarity sake the modules defined here are included
-in the descriptions.
+This module, ``calmjs.webpack``, also mostly follows the ``calmjs``
+module layout order, but for clarity sake the modules defined here are
+included in the descriptions.
 
 interrogation
     Helpers for interrogating a webpack artifact file.
@@ -26,7 +26,9 @@ env
 
 loaderplugin
     Integration with the loader plugin system; include the base loader
-    plugins and an automatic registry system.
+    plugins and an automatic registry system.  Note that for the webpack
+    integration, loaderplugins have a much higher precedence as both the
+    toolchain and cli will require this module.
 
 registry
     Currently contain just one registry implementation, which is for

--- a/src/calmjs/webpack/base.py
+++ b/src/calmjs/webpack/base.py
@@ -5,6 +5,8 @@ Base classes and constants.
 
 from __future__ import unicode_literals
 
+from collections import namedtuple
+
 # keys
 
 # enable calmjs compatibility - i.e. the dynamic import feature
@@ -67,3 +69,11 @@ DEFAULT_BOOTSTRAP_EXPORT_CONFIG = {
     "root": DEFAULT_BOOTSTRAP_EXPORT,
     "amd": DEFAULT_BOOTSTRAP_EXPORT,
 }
+
+
+# due to webpack specific requirements, a special type for the key is
+# needed for the WebpackModuleLoaderRegistry such that the correct
+# handling mechanism may be done.
+CALMJS_WEBPACK_MODULE_LOADER_SUFFIX = '.webpackloader'
+WebpackModuleLoaderRegistryKey = namedtuple(
+    'WebpackModuleLoaderRegistryKey', ['loader', 'modname'])

--- a/src/calmjs/webpack/base.py
+++ b/src/calmjs/webpack/base.py
@@ -11,6 +11,11 @@ from collections import namedtuple
 
 # enable calmjs compatibility - i.e. the dynamic import feature
 CALMJS_COMPAT = 'calmjs_compat'
+# the map from a module name to the loader needed; used by the various
+# functions and methods in the loaderplugin module
+# see definition of WebpackModuleLoaderRegistryKey later
+CALMJS_WEBPACK_MODNAME_LOADER_MAP = 'calmjs_webpack_modname_loader_map'
+
 # The spec key for storing the base webpack configuration.
 WEBPACK_CONFIG = 'webpack_config'
 # The key for the webpack.output.library
@@ -25,6 +30,8 @@ WEBPACK_ENTRY_POINT = 'webpack_entry_point'
 # For webpack loaderplugin integration - this is the spec key - note that
 # this is NOT for webpack plugins which are a separate type of things
 WEBPACK_LOADERPLUGINS = 'webpack_loaderplugins'
+# for the module.rules section; used by loaderplugin module
+WEBPACK_MODULE_RULES = 'webpack_module_rules'
 # for the configuration in webpack config
 WEBPACK_RESOLVELOADER_ALIAS = 'webpack_resolveloader_alias'
 

--- a/src/calmjs/webpack/dev.py
+++ b/src/calmjs/webpack/dev.py
@@ -264,9 +264,14 @@ def _apply_coverage(toolchain, spec):
     if not loader:
         return
     config = spec[karma.KARMA_CONFIG]
-    module = config['webpack']['module'] = config['webpack'].get('module', {})
-    loaders = module['loaders'] = module.get('loaders', [])
-    loaders.append(loader)
+    rules = _apply_webpack_module_rules(config['webpack'])
+    rules.append(loader)
+
+
+def _apply_webpack_module_rules(webpack_config):
+    module = webpack_config['module'] = webpack_config.get('module', {})
+    rules = module['rules'] = module.get('rules', [])
+    return rules
 
 
 def karma_webpack(spec, toolchain=None):

--- a/src/calmjs/webpack/dist.py
+++ b/src/calmjs/webpack/dist.py
@@ -126,7 +126,7 @@ def _generate_transpile_maps(
 
 
 def generate_transpile_sourcepaths(
-        package_names, registries=('calmjs.modules'), method=_default):
+        package_names, registries=('calmjs.modules',), method=_default):
     """
     Invoke the module_registry_dependencies family of dist functions,
     with the specified registries, to produce the required the module
@@ -163,7 +163,7 @@ def generate_transpile_sourcepaths(
 
 
 def generate_transpiled_externals(
-        package_names, registries=('calmjs.modules'), method=_default):
+        package_names, registries=('calmjs.modules',), method=_default):
     """
     Webpack specific - for every call to generate_transpile_sourcepaths
     with the results assigned to the transpile_sourcepaths of a spec, an

--- a/src/calmjs/webpack/loaderplugin.py
+++ b/src/calmjs/webpack/loaderplugin.py
@@ -137,6 +137,10 @@ class WebpackLoaderHandler(NPMLoaderPluginHandler, BaseWebpackLoaderHandler):
 
     @property
     def node_module_pkg_name(self):
+        # TODO figure out how to make this fallback?
+        # i.e. pre-process using locate_package_entry_file?
+        # modify generate_handler_sourcepath so that it calls
+        # a thing that sets a private attribute for this?
         return self.name + '-loader'
 
 

--- a/src/calmjs/webpack/loaderplugin.py
+++ b/src/calmjs/webpack/loaderplugin.py
@@ -14,6 +14,9 @@ from os.path import exists
 from os.path import join
 
 from calmjs.toolchain import BUILD_DIR
+from calmjs.loaderplugin import ModuleLoaderRegistry
+from calmjs.webpack.base import CALMJS_WEBPACK_MODULE_LOADER_SUFFIX
+from calmjs.webpack.base import WebpackModuleLoaderRegistryKey
 
 from calmjs.loaderplugin import LoaderPluginRegistry
 from calmjs.loaderplugin import LoaderPluginHandler
@@ -148,3 +151,20 @@ class AutogenWebpackLoaderPluginRegistry(LoaderPluginRegistry):
             self.__class__.__name__, self.registry_name, plugin_name
         )
         return AutogenWebpackLoaderHandler(self, plugin_name)
+
+
+class WebpackModuleLoaderRegistry(ModuleLoaderRegistry):
+    """
+    This webpack specific version will not include the loader prefixes
+    in the generated names, however it will provide a reverse mapping
+    which should be called to set up the loader chain.
+    """
+
+    def resolve_parent_registry_name(
+            self, registry_name, suffix=CALMJS_WEBPACK_MODULE_LOADER_SUFFIX):
+        return super(
+            WebpackModuleLoaderRegistry, self
+        ).resolve_parent_registry_name(registry_name, suffix)
+
+    def generate_complete_modname(self, prefix, modname, extension):
+        return WebpackModuleLoaderRegistryKey(prefix, modname + extension)

--- a/src/calmjs/webpack/testing/utils.py
+++ b/src/calmjs/webpack/testing/utils.py
@@ -23,6 +23,26 @@ def skip_full_toolchain_test():  # pragma: no cover
     return (False, '')
 
 
+def create_mock_npm_package(
+        working_dir, package_name, entry_point, version='0.0.1'):
+    module_root = join(working_dir, 'node_modules', package_name)
+    module_cfg = join(module_root, 'package.json')
+    module_src = join(module_root, entry_point)
+
+    os.makedirs(module_root)
+    with open(module_cfg, 'w') as fd:
+        json.dump({
+            "name": package_name,
+            "version": version,
+            "main": entry_point,
+        }, fd)
+
+    with open(module_src, 'w') as fd:
+        fd.write("(function(){})();")
+
+    return module_src
+
+
 def cls_setup_webpack_loader_integration_packages(cls):
     # cls.dist_dir created by setup_class_integration_environment
     cls._es_root = join(cls.dist_dir, 'example', 'styledemo')

--- a/src/calmjs/webpack/testing/utils.py
+++ b/src/calmjs/webpack/testing/utils.py
@@ -86,6 +86,7 @@ def cls_setup_webpack_loader_integration_packages(cls):
             '"use strict";\n'
             '\n'
             'var styledemo = require("example/styledemo/index");\n'
+            'var text = require("example/styledemo/tests/hello.txt");\n'
             '\n'
             'describe("styling test cases", function() {\n'
             '    afterEach(function() {\n'
@@ -94,6 +95,10 @@ def cls_setup_webpack_loader_integration_packages(cls):
             '\n'
             '    it("we got toast", function() {\n'
             '        expect(styledemo.toast("toast")).equal("toast");\n'
+            '    });\n'
+            '\n'
+            '    it("text is hello", function() {\n'
+            '        expect(text).equal("hello world");\n'
             '    });\n'
             '\n'
             '    it("styles are available", function() {\n'
@@ -127,6 +132,9 @@ def cls_setup_webpack_loader_integration_packages(cls):
             '.tr { border: 1px solid #f00; }\n'
         )
 
+    with open(join(cls._es_root, 'tests', 'hello.txt'), 'w') as fd:
+        fd.write('hello world')
+
     # tie everything together with the webpackloader registry
     utils.make_dummy_dist(None, (
         ('requires.txt', ''),
@@ -134,6 +142,9 @@ def cls_setup_webpack_loader_integration_packages(cls):
             'dependencies': {
                 'style-loader': '~0.21.0',
                 'css-loader': '~0.28.11',
+            },
+            'devDependencies': {
+                'text-loader': '~0.0.1',
             },
         })),
         ('calmjs_module_registry.txt', '\n'.join([
@@ -146,16 +157,14 @@ def cls_setup_webpack_loader_integration_packages(cls):
         # throw in some .tests.webpackloader under the tests too?
         # or also .tests.loader
         ('entry_points.txt', (
-            '[%s]\n'
+            '[{0}]\n'
             'example.styledemo = example.styledemo\n'
-            '[%s.tests]\n'
+            '[{0}.tests]\n'
             'example.styledemo.tests = example.styledemo.tests\n'
-            '[%s.webpackloader]\n'
-            'style!css = stylesheets[css]\n' % (
-                cls.registry_name,
-                cls.registry_name,
-                cls.registry_name,
-            )
+            '[{0}.webpackloader]\n'
+            'style!css = stylesheets[css]\n'
+            '[{0}.tests.webpackloader]\n'
+            'text-loader = text[txt]\n'.format(cls.registry_name)
         )),
     ), 'example.styledemo', '1.0', working_dir=cls.dist_dir)
 
@@ -167,6 +176,7 @@ def cls_setup_webpack_loader_integration_packages(cls):
         cls.registry_name,
         cls.registry_name + '.tests',
         cls.registry_name + '.webpackloader',
+        cls.registry_name + '.tests.webpackloader',
     )
 
 

--- a/src/calmjs/webpack/testing/utils.py
+++ b/src/calmjs/webpack/testing/utils.py
@@ -13,7 +13,6 @@ from pkg_resources import resource_filename
 from calmjs.registry import get as get_registry
 from calmjs.testing import utils
 from calmjs.npm import get_npm_version
-from calmjs import dist as calmjs_dist
 
 
 def skip_full_toolchain_test():  # pragma: no cover
@@ -22,6 +21,133 @@ def skip_full_toolchain_test():  # pragma: no cover
     if os.environ.get('SKIP_FULL'):
         return (True, 'skipping due to SKIP_FULL environment variable')
     return (False, '')
+
+
+def cls_setup_webpack_loader_integration_packages(cls):
+    # cls.dist_dir created by setup_class_integration_environment
+    cls._es_root = join(cls.dist_dir, 'example', 'styledemo')
+    # make the testdir also
+    makedirs(join(cls._es_root, 'tests'))
+
+    # TODO should move this to a different function
+    utils.make_dummy_dist(None, (
+        ('entry_points.txt', '\n'.join([
+            '[calmjs.registry]',
+            cls.registry_name + '.webpackloader = ' +
+            'calmjs.webpack.loaderplugin:WebpackModuleLoaderRegistry',
+
+            cls.registry_name + '.tests.webpackloader = ' +
+            'calmjs.webpack.loaderplugin:WebpackModuleLoaderRegistry',
+
+        ])),
+    ), 'calmjs.webpack.simulated', '420', working_dir=cls.dist_dir)
+
+    index_js = join(cls._es_root, 'index.js')
+    with open(index_js, 'w') as fd:
+        fd.write(
+            '"use strict";\n'
+            '\n'
+            'require("example/styledemo/index.css")\n'
+            '\n'
+            'exports.toast = function(msg) {\n'
+            '    console.log("popped some toasted messages");\n'
+            '    return msg;\n'
+            '};\n'
+        )
+
+    # definitely need to also pass this through karma integration tests
+    # as the module.rules may conflict, and that ensure the css files do
+    # NOT get further rules applied for coverage reporting as that can
+    # complicate things.
+    test_index_js = join(cls._es_root, 'tests', 'test_index.js')
+    with open(test_index_js, 'w') as fd:
+        # TODO include a test on application of stylesheet?
+        fd.write(
+            '"use strict";\n'
+            '\n'
+            'var styledemo = require("example/styledemo/index");\n'
+            '\n'
+            'describe("styling test cases", function() {\n'
+            '    afterEach(function() {\n'
+            '        document.body.innerHTML = ""\n'
+            '    });\n'
+            '\n'
+            '    it("we got toast", function() {\n'
+            '        expect(styledemo.toast("toast")).equal("toast");\n'
+            '    });\n'
+            '\n'
+            '    it("styles are available", function() {\n'
+            '        document.body.innerHTML = \'<div id="root"></div>\';\n'
+            '        var element = document.getElementById("root");\n'
+            '        element.setAttribute("class", "body");\n'
+            '        var style = window.getComputedStyle(element);\n'
+            '        expect(style.getPropertyValue(\n'
+            '            "background-color")).equal("rgb(204, 204, 204)");\n'
+            '        element.setAttribute("class", "div");\n'
+            '        var style = window.getComputedStyle(element);\n'
+            '        expect(style.getPropertyValue(\n'
+            '            "background-color")).equal("rgb(238, 238, 238)");\n'
+            '    });\n'
+            '});\n'
+        )
+
+    index_css = join(cls._es_root, 'index.css')
+    with open(index_css, 'w') as fd:
+        fd.write(
+            "@import url('example/styledemo/extra.css');\n"
+            '\n'
+            '.body { background: #ccc; }\n'
+            '.div { background: #eee; }\n'
+        )
+
+    extra_css = join(cls._es_root, 'extra.css')
+    with open(extra_css, 'w') as fd:
+        fd.write(
+            '.table { border: 1px solid #000; }\n'
+            '.tr { border: 1px solid #f00; }\n'
+        )
+
+    # tie everything together with the webpackloader registry
+    utils.make_dummy_dist(None, (
+        ('requires.txt', ''),
+        ('package.json', json.dumps({
+            'dependencies': {
+                'style-loader': '~0.21.0',
+                'css-loader': '~0.28.11',
+            },
+        })),
+        ('calmjs_module_registry.txt', '\n'.join([
+            cls.registry_name,
+            # note that this may become optionally specified, perhaps
+            # remove it when that time comes.
+            # TODO remove when implied subregistries is implemented
+            cls.registry_name + '.webpackloader',
+        ])),
+        # throw in some .tests.webpackloader under the tests too?
+        # or also .tests.loader
+        ('entry_points.txt', (
+            '[%s]\n'
+            'example.styledemo = example.styledemo\n'
+            '[%s.tests]\n'
+            'example.styledemo.tests = example.styledemo.tests\n'
+            '[%s.webpackloader]\n'
+            'style!css = stylesheets[css]\n' % (
+                cls.registry_name,
+                cls.registry_name,
+                cls.registry_name,
+            )
+        )),
+    ), 'example.styledemo', '1.0', working_dir=cls.dist_dir)
+
+    # re-add dist_dir to working set
+    cls.working_set.add_entry(cls.dist_dir)
+
+    utils.instantiate_integration_registries(
+        cls.working_set, cls.root_registry,
+        cls.registry_name,
+        cls.registry_name + '.tests',
+        cls.registry_name + '.webpackloader',
+    )
 
 
 def cls_setup_webpack_example_package(cls):
@@ -277,7 +403,8 @@ def cls_setup_webpack_example_package(cls):
     with open(json_data, 'w') as fd:
         fd.write('{"value": "hello"}')
 
-    # create a mock distribution for loaderplugins
+    # create a mock distribution for loaderplugins integration with
+    # various webpack loaders
     utils.make_dummy_dist(None, (
         ('requires.txt', ''),
         ('calmjs_module_registry.txt', cls.registry_name),
@@ -304,8 +431,16 @@ def cls_setup_webpack_example_package(cls):
     ), 'calmjs.webpack', '0.0', working_dir=cls.dist_dir)
 
     # re-add it again
-    calmjs_dist.default_working_set.add_entry(cls.dist_dir)
-    # TODO produce package_module_map
+    cls.working_set.add_entry(cls.dist_dir)
+
+    # Under typical circumstances, we can do this
+    # utils.instantiate_integration_registries(
+    #     cls.working_set, cls.root_registry,
+    #     cls.registry_name,
+    #     cls.registry_name + '.tests',
+    # )
+    # However, we have existing sources that are to be omitted under
+    # most typical tests, hence a manual approach is done.
 
     registry = get_registry(cls.registry_name)
     record = registry.records['example.package'] = {}

--- a/src/calmjs/webpack/tests/test_dev.py
+++ b/src/calmjs/webpack/tests/test_dev.py
@@ -117,7 +117,7 @@ class KarmaTestcase(unittest.TestCase):
         dev._apply_coverage(None, spec)
 
         self.assertEqual({
-            "module": {"loaders": [{
+            "module": {"rules": [{
                 "loader": "sourcemap-istanbul-instrumenter-loader",
                 "include": [
                     'some/test/file', join(spec['build_dir'], 'afile.js')
@@ -130,8 +130,7 @@ class KarmaTestcase(unittest.TestCase):
             karma_config={
                 'webpack': {
                     'module': {
-                        'rules': [],
-                        'loaders': [
+                        'rules': [
                             {'loader': 'demo-loader'}
                         ],
                     },
@@ -144,7 +143,7 @@ class KarmaTestcase(unittest.TestCase):
         dev._apply_coverage(None, spec)
 
         self.assertEqual({
-            "module": {'rules': [], "loaders": [{'loader': 'demo-loader'}, {
+            "module": {"rules": [{'loader': 'demo-loader'}, {
                 "loader": "sourcemap-istanbul-instrumenter-loader",
                 "include": [
                     'some/test/file', join(spec['build_dir'], 'afile.js')

--- a/src/calmjs/webpack/tests/test_integration.py
+++ b/src/calmjs/webpack/tests/test_integration.py
@@ -1647,11 +1647,12 @@ class KarmaToolchainIntegrationTestCase(unittest.TestCase):
         with self.assertRaises(SystemExit) as e:
             runtime.main([
                 'karma',
-                # TODO remove after release of calmjs.dev-2.2.0, as the
-                # automatic resolution of loaders the test registries
-                # should work, same as below.
-                '--test-registry=calmjs.module.simulated.tests,'
-                'calmjs.module.simulated.tests.webpackloader',
+                # note that the following --test-registry is required
+                # for calmjs-dev<2.2.0, as it does not know about the
+                # correct way to apply test loader repositories until
+                # then.
+                # '--test-registry=calmjs.module.simulated.tests,'
+                # 'calmjs.module.simulated.tests.webpackloader',
                 'webpack', 'example.styledemo',
                 '--export-target=' + export_target,
             ])
@@ -1676,9 +1677,6 @@ class KarmaToolchainIntegrationTestCase(unittest.TestCase):
             runtime.main([
                 'karma', '--coverage', '--cover-test',
                 '--cover-report-dir=' + build_dir,
-                # TODO remove test-registry flag
-                '--test-registry=calmjs.module.simulated.tests,'
-                'calmjs.module.simulated.tests.webpackloader',
                 'webpack', 'example.styledemo',
                 '--export-target=' + export_target,
                 '--build-dir=' + build_dir,
@@ -1714,12 +1712,8 @@ class KarmaToolchainIntegrationTestCase(unittest.TestCase):
             runtime.main([
                 'karma', 'run',
                 '--test-with-package', 'example.styledemo',
-                # note the omitted --test-registry
                 '--artifact', export_target,
                 '--toolchain-package', 'calmjs.webpack',
-                # TODO remove test-registry flag
-                '--test-registry=calmjs.module.simulated.tests,'
-                'calmjs.module.simulated.tests.webpackloader',
             ])
         # tests should pass against the resultant bundle
         self.assertEqual(e.exception.args[0], 0)

--- a/src/calmjs/webpack/tests/test_integration.py
+++ b/src/calmjs/webpack/tests/test_integration.py
@@ -17,6 +17,7 @@ from calmjs.cli import node
 from calmjs import runtime
 from calmjs.utils import pretty_logging
 from calmjs.registry import get as get_registry
+from calmjs.loaderplugin import LoaderPluginRegistry
 
 from calmjs.parse.parsers.es5 import parse
 from calmjs.parse.walkers import ReprWalker
@@ -30,6 +31,7 @@ from calmjs.webpack import toolchain
 from calmjs.webpack import cli
 from calmjs.webpack import exc
 from calmjs.webpack import interrogation
+from calmjs.webpack import loaderplugin
 from calmjs.webpack.base import CALMJS_WEBPACK_LOADERPLUGINS
 
 from calmjs.testing import utils
@@ -70,6 +72,28 @@ def _setup_extra_install(working_dir, packages):
     if not os.environ.get('CALMJS_TEST_ENV'):  # pragma: no cover
         driver = Driver(working_dir=working_dir)
         driver.pkg_manager_install(packages, production=False, merge=True)
+
+
+class RegistryRegisteredTests(unittest.TestCase):
+
+    def test_registry_registered(self):
+        # ensure that the registries are actually working
+        self.assertTrue(isinstance(
+            get_registry('calmjs.webpack.loaderplugins'),
+            loaderplugin.AutogenWebpackLoaderPluginRegistry,
+        ))
+        self.assertTrue(isinstance(
+            get_registry('calmjs.webpack.static.loaderplugins'),
+            LoaderPluginRegistry,
+        ))
+        self.assertTrue(isinstance(
+            get_registry('calmjs.module.webpackloader'),
+            loaderplugin.WebpackModuleLoaderRegistry,
+        ))
+        self.assertTrue(isinstance(
+            get_registry('calmjs.module.tests.webpackloader'),
+            loaderplugin.WebpackModuleLoaderRegistry,
+        ))
 
 
 @unittest.skipIf(*skip_full_toolchain_test())

--- a/src/calmjs/webpack/tests/test_integration.py
+++ b/src/calmjs/webpack/tests/test_integration.py
@@ -1408,7 +1408,7 @@ class ToolchainIntegrationTestCase(unittest.TestCase):
 
 
 @unittest.skipIf(karma is None, 'calmjs.dev or its karma module not available')
-class KarmatoolchainIntegrationTestCase(unittest.TestCase):
+class KarmaToolchainIntegrationTestCase(unittest.TestCase):
     """
     Test out the karma toolchain, involving webpack completely along
     with the karma testing framework as defined by calmjs.dev
@@ -1481,10 +1481,12 @@ class KarmatoolchainIntegrationTestCase(unittest.TestCase):
         utils.stub_stdouts(self)
         current_dir = utils.mkdtemp(self)
         build_dir = utils.mkdtemp(self)
+        report_dir = utils.mkdtemp(self)
         export_target = join(current_dir, 'example_package.js')
         with self.assertRaises(SystemExit) as e:
             runtime.main([
                 'karma', '--coverage',
+                '--cover-report-dir=' + report_dir,
                 'webpack', 'example.package',
                 '--export-target=' + export_target,
                 '--build-dir=' + build_dir,
@@ -1493,7 +1495,7 @@ class KarmatoolchainIntegrationTestCase(unittest.TestCase):
         self.assertTrue(exists(export_target))
 
         # verify that the coverage was recorded only for packge
-        coverage_file = join(self._env_root, 'coverage', 'coverage.json')
+        coverage_file = join(report_dir, 'coverage.json')
         with codecs.open(coverage_file, encoding='utf8') as fd:
             coverage = json.load(fd)
         expected = {
@@ -1507,10 +1509,12 @@ class KarmatoolchainIntegrationTestCase(unittest.TestCase):
         utils.stub_stdouts(self)
         current_dir = utils.mkdtemp(self)
         build_dir = utils.mkdtemp(self)
+        report_dir = utils.mkdtemp(self)
         export_target = join(current_dir, 'example_package.js')
         with self.assertRaises(SystemExit) as e:
             runtime.main([
                 'karma', '--coverage', '--cover-test',
+                '--cover-report-dir=' + report_dir,
                 'webpack', 'example.package',
                 '--export-target=' + export_target,
                 '--build-dir=' + build_dir,
@@ -1519,7 +1523,7 @@ class KarmatoolchainIntegrationTestCase(unittest.TestCase):
         self.assertTrue(exists(export_target))
 
         # verify that the coverage was recorded for test also.
-        coverage_file = join(self._env_root, 'coverage', 'coverage.json')
+        coverage_file = join(report_dir, 'coverage.json')
         with codecs.open(coverage_file, encoding='utf8') as fd:
             coverage = json.load(fd)
         expected = {
@@ -1546,10 +1550,12 @@ class KarmatoolchainIntegrationTestCase(unittest.TestCase):
         utils.stub_stdouts(self)
         current_dir = utils.mkdtemp(self)
         build_dir = utils.mkdtemp(self)
+        report_dir = utils.mkdtemp(self)
         export_target = join(current_dir, 'example_extras.js')
         with self.assertRaises(SystemExit) as e:
             runtime.main([
                 'karma', '--coverage', '--cover-test',
+                '--cover-report-dir=' + report_dir,
                 'webpack', 'example.extras',
                 '--export-target=' + export_target,
                 '--build-dir=' + build_dir,
@@ -1558,7 +1564,7 @@ class KarmatoolchainIntegrationTestCase(unittest.TestCase):
         self.assertTrue(exists(export_target))
 
         # verify that the coverage was recorded.
-        coverage_file = join(self._env_root, 'coverage', 'coverage.json')
+        coverage_file = join(report_dir, 'coverage.json')
         with codecs.open(coverage_file, encoding='utf8') as fd:
             coverage = json.load(fd)
         expected = {

--- a/src/calmjs/webpack/tests/test_toolchain.py
+++ b/src/calmjs/webpack/tests/test_toolchain.py
@@ -21,25 +21,11 @@ from calmjs.webpack.loaderplugin import AutogenWebpackLoaderPluginRegistry
 
 from calmjs.testing import utils
 from calmjs.testing import mocks
+from calmjs.webpack.testing.utils import create_mock_npm_package
 
 
 def mock_text_loader(working_dir):
-    module_root = join(working_dir, 'node_modules', 'text-loader')
-    module_cfg = join(module_root, 'package.json')
-    module_src = join(module_root, 'text.js')
-
-    # create the dummy text-loader package.json entry, using just the
-    # bare required information from the real package.
-    os.makedirs(module_root)
-    with open(module_cfg, 'w') as fd:
-        json.dump({
-            "name": "text-loader",
-            "version": "0.0.1",
-            "main": "index.js",
-            "license": "ISC",
-        }, fd)
-
-    return module_src
+    return create_mock_npm_package(working_dir, 'text-loader', 'text.js')
 
 
 class CheckNameTestCase(unittest.TestCase):

--- a/src/calmjs/webpack/toolchain.py
+++ b/src/calmjs/webpack/toolchain.py
@@ -37,6 +37,8 @@ from calmjs.parse.utils import repr_compat
 
 from calmjs.webpack.manipulation import convert_dynamic_require_unparser
 from calmjs.webpack.base import DEFAULT_CALMJS_EXPORT_NAME
+from calmjs.webpack.base import WEBPACK_MODULE_RULES
+from calmjs.webpack.loaderplugin import update_spec_webpack_loaders_modules
 
 from .dev import webpack_advice
 from .env import webpack_env
@@ -378,6 +380,7 @@ class WebpackToolchain(ES5Toolchain):
                 'alias': spec.get(WEBPACK_RESOLVELOADER_ALIAS, {}),
             },
             'externals': spec.get(WEBPACK_EXTERNALS, {}),
+            'module': {},
         }
         if WEBPACK_OUTPUT_LIBRARY in spec:
             webpack_config['output']['library'] = spec[WEBPACK_OUTPUT_LIBRARY]
@@ -510,6 +513,9 @@ class WebpackToolchain(ES5Toolchain):
                     "or externals: %s",
                     ', '.join(sorted(repr_compat(m) for m in missing))
                 )
+
+        update_spec_webpack_loaders_modules(spec, alias)
+        webpack_config['module']['rules'] = spec.get(WEBPACK_MODULE_RULES, [])
 
         # write the configuration file, after everything is checked.
         self.write_webpack_config(spec, webpack_config)


### PR DESCRIPTION
Integrate the `calmjs-3.3.0` loader module registries along with an extended registry class to support webpack `module.rules` method of defining loaders.  This is still work in progress (although mostly done) as the full change is pending on the release of `calmjs.dev-2.2.0` so that the test registries for loaders will be resolved correctly.

Also the changelog entry will need further completion as it is missing a few pieces of key information and notes (like the correction to the karma webpack configuration).