### PR TITLE
Line continuation mark should be neutralised

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+1.1.1 (2018-08-??)
+------------------
+
+- Ensure the line-continuation mark is filtered out in the to_identifier
+  helper function as the values of String node object included that mark
+  as of ``calmjs.parse-1.1.0``.  [
+  `#7 <https://github.com/calmjs/calmjs.webpack/issues/7>`_
+  ]
+
 1.1.0 (2018-07-25)
 ------------------
 

--- a/src/calmjs/webpack/interrogation.py
+++ b/src/calmjs/webpack/interrogation.py
@@ -133,8 +133,14 @@ def to_identifier(node):
         # unicode-escape to encode all the things - and then strip off
         # the doubly escaped backslashes for everything and bring it
         # back by decoding again with unicode-escape.
-        return node.value[1:-1].encode('unicode-escape').replace(
-            b'\\\\', b'\\').decode('unicode-escape')
+        return node.value[1:-1].replace(
+            # Note that the line continuation mark is included with the
+            # AST since calmjs.parse-1.1.0; strip this out before doing
+            # the unicode-escape dance.
+            '\\\n', '').encode(
+            'unicode-escape').replace(
+            b'\\\\', b'\\').decode(
+            'unicode-escape')
     else:
         # assume to be an Identifier
         return node.value

--- a/src/calmjs/webpack/testing/examples/unusual_names.js
+++ b/src/calmjs/webpack/testing/examples/unusual_names.js
@@ -12,4 +12,7 @@ var examples = [
     {"\u3042": 0},
     {"\
     ": 0},
+    {"foo\
+bar": 0},
 ];
+console.log(examples);

--- a/src/calmjs/webpack/tests/test_interrogation.py
+++ b/src/calmjs/webpack/tests/test_interrogation.py
@@ -84,6 +84,7 @@ class WebpackTestCase(unittest.TestCase):
             "\u3042",
             "\u3042",
             "    ",
+            "foobar",
         ]
         for a, r in zip(answers, (o for o in interrogation.walker.filter(
                 _unusual_names, lambda node: isinstance(node, Object)))):


### PR DESCRIPTION
As the `calmjs-parse-1.1.0` include the mark as part of the value for the `String` nodes, this particular token must also be turned into an empty string such that no additional characters are done.  Also modified the example script so that when executed with Node.js, the intended output for the module names are rendered.